### PR TITLE
activate debug extension while in processwire debug mode

### DIFF
--- a/TemplateTwigReplace.module
+++ b/TemplateTwigReplace.module
@@ -283,10 +283,12 @@ class TemplateTwigReplace extends WireData implements Module, ConfigurableModule
         $options = array(
             'cache'         => $cache,
             'auto_reload'   => (boolean)$this->data['cacheAutoReload'],
-            'autoescape'    => $this->data['autoEscape']
+            'autoescape'    => $this->data['autoEscape'],
+            'debug'         => wire('config')->debug
         );
 
         $this->twig = new Twig_Environment($loader, $options);
+        $this->twig->addExtension(new Twig_Extension_Debug());
 
         return $this->twig;
     }


### PR DESCRIPTION
This brings in the twig `{{ dump(var) }}` function for easy debugging in your templates.
