### PR TITLE
adding support for prepending and appending files

### DIFF
--- a/TemplateTwigReplace.module
+++ b/TemplateTwigReplace.module
@@ -6,7 +6,8 @@
  * See README.md for usage instructions.
  *
  * @author Marco Stoll <marco.stoll@neuwaerts.de>
- * @version 1.0.5
+ * @author Tabea David <td@kf-interactive.com>
+ * @version 1.0.6
  * @copyright Copyright (c) 2014, neuwaerts GmbH
  * @filesource
  * @see https://github.com/marcostoll/processwire-template-twig-replace
@@ -23,11 +24,11 @@ class TemplateTwigReplace extends WireData implements Module, ConfigurableModule
      * @field array Default config values
      */
     protected static $defaults = array(
-        'fuel'              => 'page, pages, config, session, user, input',
-        'cacheEnable'       => false,
-        'cacheDir'          => 'twig/',
-        'cacheAutoReload'   => true,
-        'autoEscape'        => false
+      'fuel'              => 'page, pages, config, session, user, input',
+      'cacheEnable'       => false,
+      'cacheDir'          => 'twig/',
+      'cacheAutoReload'   => true,
+      'autoEscape'        => false
     );
 
     /**
@@ -43,33 +44,31 @@ class TemplateTwigReplace extends WireData implements Module, ConfigurableModule
      * @return array
      * @see http://processwire.com/apigen/class-Module.html
      */
-	public static function getModuleInfo() {
+    public static function getModuleInfo() {
+      return array(
+        // The module'ss title, typically a little more descriptive than the class name
+        'title' => 'Template Twig Replace',
 
-		return array(
+        // version: major, minor, revision, i.e. 100 = 1.0.0
+        'version' => 106,
 
-			// The module'ss title, typically a little more descriptive than the class name
-			'title' => 'Template Twig Replace',
+        // summary is brief description of what this module is
+        'summary' => 'Use Twig template engine instead of plain-php templates',
 
-			// version: major, minor, revision, i.e. 100 = 1.0.0
-			'version' => 105,
+        // Optional URL to more information about the module
+        'href' => 'https://github.com/marcostoll/processwire-template-twig-replace',
 
-			// summary is brief description of what this module is
-			'summary' => 'Use Twig template engine instead of plain-php templates',
-			
-			// Optional URL to more information about the module
-			'href' => 'https://github.com/marcostoll/processwire-template-twig-replace',
+        // singular=true: indicates that only one instance of the module is allowed.
+        // This is usually what you want for modules that attach hooks.
+        'singular' => true,
 
-			// singular=true: indicates that only one instance of the module is allowed.
-			// This is usually what you want for modules that attach hooks. 
-			'singular' => true, 
-
-			// autoload=true: indicates the module should be started with ProcessWire.
-			// This is necessary for any modules that attach runtime hooks, otherwise those
-			// hooks won't get attached unless some other code calls the module on it's own.
-			// Note that autoload modules are almost always also 'singular' (seen above).
-			'autoload' => true, 
-		);
-	}
+        // autoload=true: indicates the module should be started with ProcessWire.
+        // This is necessary for any modules that attach runtime hooks, otherwise those
+        // hooks won't get attached unless some other code calls the module on it's own.
+        // Note that autoload modules are almost always also 'singular' (seen above).
+        'autoload' => true,
+      );
+    }
 
     /**
      * Retrieves the list of config input fields
@@ -81,62 +80,61 @@ class TemplateTwigReplace extends WireData implements Module, ConfigurableModule
      * @see http://processwire.com/apigen/class-ConfigurableModule.html
      */
     public static function getModuleConfigInputfields(array $data) {
+      $fields = new InputfieldWrapper();
+      $modules = wire('modules');
 
-        $fields = new InputfieldWrapper();
-        $modules = wire('modules');
+      // default config values
+      $data = array_merge(self::$defaults, $data);
 
-        // default config values
-        $data = array_merge(self::$defaults, $data);
+      // fuel
+      $field = $modules->get("InputfieldText");
+      $field->name = 'fuel';
+      $field->label = "Auto-import fuel";
+      $field->description = "List ProcessWire fuel keys to automatically import as Twig variables" . PHP_EOL .
+                            "Use comma (,) or semicolon (;) as separator - with or without spaces" . PHP_EOL .
+                            "See http://processwire.com/api/variables/ for possible keys";
+      $field->size = 45;
+      $field->value = $data['fuel'];
+      $fields->append($field);
 
-        // fuel
-        $field = $modules->get("InputfieldText");
-        $field->name = 'fuel';
-        $field->label = "Auto-import fuel";
-        $field->description = "List ProcessWire fuel keys to automatically import as Twig variables" . PHP_EOL .
-                              "Use comma (,) or semicolon (;) as separator - with or without spaces" . PHP_EOL .
-                              "See http://processwire.com/api/variables/ for possible keys";
-        $field->size = 45;
-        $field->value = $data['fuel'];
-        $fields->append($field);
+      // cache enabled field
+      $field = $modules->get("InputfieldCheckbox");
+      $field->name = "cacheEnable";
+      $field->label = "Enable Twig Cache";
+      $field->description = "Enable Twig cache in production mode only" . PHP_EOL .
+                            "Caches compiled templates, not page rendering output.";
+      $field->value = 1;
+      $field->attr('checked', empty($data['cacheEnable']) ? '' : 'checked');
+      $fields->add($field);
 
-        // cache enabled field
-        $field = $modules->get("InputfieldCheckbox");
-        $field->name = "cacheEnable";
-        $field->label = "Enable Twig Cache";
-        $field->description = "Enable Twig cache in production mode only" . PHP_EOL .
-                              "Caches compiled templates, not page rendering output.";
-        $field->value = 1;
-        $field->attr('checked', empty($data['cacheEnable']) ? '' : 'checked');
-        $fields->add($field);
+      // cache directory name
+      $field = $modules->get("InputfieldText");
+      $field->name = 'cacheDir';
+      $field->label = "Twig Cache Directory";
+      $field->description = "Directory name for Twig cache (relative to wire('config')->paths->cache)";
+      $field->size = 30;
+      $field->value = $data['cacheDir'];
+      $fields->append($field);
 
-        // cache directory name
-        $field = $modules->get("InputfieldText");
-        $field->name = 'cacheDir';
-        $field->label = "Twig Cache Directory";
-        $field->description = "Directory name for Twig cache (relative to wire('config')->paths->cache)";
-        $field->size = 30;
-        $field->value = $data['cacheDir'];
-        $fields->append($field);
+      // cache auto reload
+      $field = $modules->get("InputfieldCheckbox");
+      $field->name = "cacheAutoReload";
+      $field->label = "Auto Reload Twig Cache";
+      $field->description = "Reload Twig cache on template modification";
+      $field->value = 1;
+      $field->attr('checked', empty($data['cacheAutoReload']) ? '' : 'checked');
+      $fields->add($field);
 
-        // cache auto reload
-        $field = $modules->get("InputfieldCheckbox");
-        $field->name = "cacheAutoReload";
-        $field->label = "Auto Reload Twig Cache";
-        $field->description = "Reload Twig cache on template modification";
-        $field->value = 1;
-        $field->attr('checked', empty($data['cacheAutoReload']) ? '' : 'checked');
-        $fields->add($field);
+      // auto escape variables
+      $field = $modules->get("InputfieldSelect");
+      $field->name = "autoEscape";
+      $field->label = "Auto Escape Twig variables";
+      $field->description = "Automatic escape strategy for output variable content in Twig templates";
+      $field->options = array('' => '<none>', 'html' => 'html', 'html_attr' => 'html_attr');
+      $field->value = $data['autoEscape'];
+      $fields->add($field);
 
-        // auto escape variables
-        $field = $modules->get("InputfieldSelect");
-        $field->name = "autoEscape";
-        $field->label = "Auto Escape Twig variables";
-        $field->description = "Automatic escape strategy for output variable content in Twig templates";
-        $field->options = array('' => '<none>', 'html' => 'html', 'html_attr' => 'html_attr');
-        $field->value = $data['autoEscape'];
-        $fields->add($field);
-
-        return $fields;
+      return $fields;
     }
 
     /**
@@ -173,55 +171,58 @@ class TemplateTwigReplace extends WireData implements Module, ConfigurableModule
      * @throws WirePermissionException Page is not currently viewable.
      */
     public function renderPageWithTwig(HookEvent $event) {
+      $parentEvent = $event->arguments(0); // grab event provided to PageRender::renderPage
 
-        $parentEvent = $event->arguments(0); // grab event provided to PageRender::renderPage
+      // don't mess with admin templates
+      $page = $parentEvent->object;
+      $config = $this->config;
+      if ($page->template == 'admin') return;
 
-        // don't mess with admin templates
-        $page = $parentEvent->object;
-        if ($page->template == 'admin') return;
+      // double check page's status
+      // taken from PageRender::__render()
+      if ($page->status >= Page::statusUnpublished && !$page->viewable()) {
+          throw new WirePermissionException('Page \'' . $page->url . '\' is not currently viewable.');
+      }
 
-        // double check page's status
-        // taken from PageRender::__render()
-        if ($page->status >= Page::statusUnpublished && !$page->viewable()) {
-            throw new WirePermissionException('Page \'' . $page->url . '\' is not currently viewable.');
-        }
+      // forced replacing of default page rendering behaviour
+      $event->replace = true;
 
-        // forced replacing of default page rendering behaviour
-        $event->replace = true;
+      // look for cached data
+      // taken from PageRender::__render()
+      $options = count($parentEvent->arguments) ? $parentEvent->arguments[0] : array();
+      $defaultOptions = array(
+        'prependFile' => $page->template->noPrependTemplateFile ? null : $config->prependTemplateFile,
+        'prependFiles' => $page->template->prependFile ? array($page->template->prependFile) : array(),
+        'appendFile' => $page->template->noAppendTemplateFile ? null : $config->appendTemplateFile,
+        'appendFiles' => $page->template->appendFile ? array($page->template->appendFile) : array(),
+        'forceBuildCache' => false,
+      );
+      $options = array_merge($defaultOptions, $options);
 
-        // look for cached data
-        // taken from PageRender::__render()
-        $options = count($parentEvent->arguments) ? $parentEvent->arguments[0] : array();
-        $defaultOptions = array(
-            'forceBuildCache' => false,
-        );
-        $options = array_merge($defaultOptions, $options);
+      $cacheAllowed = wire('modules')->get('PageRender')->isCacheAllowed($page);
+      $cacheFile = null;
 
-        $cacheAllowed = wire('modules')->get('PageRender')->isCacheAllowed($page);
-        $cacheFile = null;
+      if ($cacheAllowed) {
+          $cacheFile = wire('modules')->get('PageRender')->getCacheFile($page);
+          if(!$options['forceBuildCache'] && ($data = $cacheFile->get()) !== false) {
+              $parentEvent->return = $data;
+              return;
+          }
+      }
 
-        if ($cacheAllowed) {
-            $cacheFile = wire('modules')->get('PageRender')->getCacheFile($page);
-            if(!$options['forceBuildCache'] && ($data = $cacheFile->get()) !== false) {
-                $parentEvent->return = $data;
-                return;
-            }
-        }
+      // allow page fields to be accessed directly in Twig
+      // e.g. {{ page.myfield }} instead of {{ page.get('myfield') }}
+      Page::$issetHas = true;
 
-        // allow page fields to be accessed directly in Twig
-        // e.g. {{ page.myfield }} instead of {{ page.get('myfield') }}
-        Page::$issetHas = true;
+      $files = $this->getPrependAppendFiles($page, $options, $config);
+      $output = $this->combineOutput($files, $page);
 
-        // render template
-        $twigVars = $this->collectVariables($page->output);
-        $output = $this->getTwig()->render($page->template->name . '.' . wire('config')->templateExtension, $twigVars);
+      // cache combinedOutput if possible
+      // taken from PageRender::__render()
+      if (!empty($output) && $cacheAllowed && !is_null($cacheFile)) $cacheFile->save($output);
 
-        // cache output if possible
-        // taken from PageRender::__render()
-        if (!empty($output) && $cacheAllowed && !is_null($cacheFile)) $cacheFile->save($output);
-
-        // manually set return of original event
-        $parentEvent->return = $output;
+      // manually set return of original event
+      $parentEvent->return = $output;
     }
 
     /**
@@ -234,18 +235,17 @@ class TemplateTwigReplace extends WireData implements Module, ConfigurableModule
      * @see https://github.com/marcostoll/processwire-template-data-providers
      */
     public function renderChunkWithTwig(HookEvent $event) {
+      $chunkController = $event->arguments(0);
 
-        $chunkController = $event->arguments(0);
+      // forced replacing of default page rendering behaviour
+      $event->replace = true;
 
-        // forced replacing of default page rendering behaviour
-        $event->replace = true;
+      // render template
+      $twigVars = $this->collectVariables($chunkController);
+      $output = $this->getTwig()->render($chunkController->getChunk(), $twigVars);
 
-        // render template
-        $twigVars = $this->collectVariables($chunkController);
-        $output = $this->getTwig()->render($chunkController->getChunk(), $twigVars);
-
-        // manually set return of original event
-        $event->return = $output;
+      // manually set return of original event
+      $event->return = $output;
     }
 
     /**
@@ -257,16 +257,15 @@ class TemplateTwigReplace extends WireData implements Module, ConfigurableModule
      * @return array
      */
     protected function collectVariables(WireData $dataProvider) {
+      $variables = array();
+      $fuel = preg_split('/\s*[,;]\s*/', $this->data['fuel'], - 1, PREG_SPLIT_NO_EMPTY);
+      foreach ($fuel as $key) {
+          $variables[$key] = wire($key);
+      }
 
-        $variables = array();
-        $fuel = preg_split('/\s*[,;]\s*/', $this->data['fuel'], - 1, PREG_SPLIT_NO_EMPTY);
-        foreach ($fuel as $key) {
-            $variables[$key] = wire($key);
-        }
+      $variables = array_merge($variables, $dataProvider->getArray());
 
-        $variables = array_merge($variables, $dataProvider->getArray());
-
-        return $variables;
+      return $variables;
     }
 
     /**
@@ -275,21 +274,97 @@ class TemplateTwigReplace extends WireData implements Module, ConfigurableModule
      * @return Twig_Environment
      */
     public function getTwig() {
+      if (!is_null($this->twig)) return $this->twig;
 
-        if (!is_null($this->twig)) return $this->twig;
+      $cache = $this->data['cacheEnable'] ? wire('config')->paths->cache . $this->data['cacheDir'] : false;
+      $loader = new Twig_Loader_Filesystem(wire('config')->paths->templates);
+      $options = array(
+        'cache'         => $cache,
+        'auto_reload'   => (boolean)$this->data['cacheAutoReload'],
+        'autoescape'    => $this->data['autoEscape'],
+        'debug'         => wire('config')->debug
+      );
 
-        $cache = $this->data['cacheEnable'] ? wire('config')->paths->cache . $this->data['cacheDir'] : false;
-        $loader = new Twig_Loader_Filesystem(wire('config')->paths->templates);
-        $options = array(
-            'cache'         => $cache,
-            'auto_reload'   => (boolean)$this->data['cacheAutoReload'],
-            'autoescape'    => $this->data['autoEscape'],
-            'debug'         => wire('config')->debug
-        );
+      $this->twig = new Twig_Environment($loader, $options);
+      $this->twig->addExtension(new Twig_Extension_Debug());
 
-        $this->twig = new Twig_Environment($loader, $options);
-        $this->twig->addExtension(new Twig_Extension_Debug());
-
-        return $this->twig;
+      return $this->twig;
     }
+
+    /**
+     * Adds prepend and append files if set
+     *
+     * @param Page $page
+     * @param array $options
+     * @param Config $config
+     * @return array
+     */
+    private function getPrependAppendFiles($page, $options, $config) {
+      // core output first to get prepend and append files working
+      $output = $page->output(true);
+
+      if ($output) {
+
+        // global prepend/append include files apply only to user-defined templates, not system templates
+        if(!($page->template->flags & Template::flagSystem)) {
+
+          foreach(array('prependFile' => 'prependFiles', 'appendFile' => 'appendFiles') as $singular => $plural) {
+            if ($options[$singular]) array_unshift($options[$plural], $options[$singular]);
+
+            foreach($options[$plural] as $file) {
+              if (!ctype_alnum(str_replace(array(".", "-", "_", "/"), "", $file))) continue;
+              if (strpos($file, '..') !== false || strpos($file, '/.') !== false) continue;
+              $file = $config->paths->templates . trim($file, '/');
+              if (!is_file($file)) continue;
+              if ($plural == 'prependFiles') $output->setPrependFilename($file);
+                else $output->setAppendFilename($file);
+            }
+          }
+        }
+
+        // pass along the $options as a local variable to the template so that one can provide their
+        // own additional variables in it if they want to
+        $output->set('options', $options);
+      }
+
+      $prepend = array();
+      if (count($output->prependFilename) > 0) {
+        foreach ($output->prependFilename as $file) {
+          $prepend[] = new TemplateFile($file);
+        }
+      }
+
+      $append = array();
+      if (count($output->appendFilename) > 0) {
+        foreach ($output->appendFilename as $file) {
+          $append[] = new TemplateFile($file);
+        }
+      }
+
+      return array('prepend' => $prepend, 'append' => $append);
+    }
+
+    /**
+     * combine output
+     *
+     * @param array $files
+     * @param Page $page
+     */
+    private function combineOutput($files, $page) {
+      $twigVars = $this->collectVariables($page->output);
+
+      $output = '';
+      foreach ($files['prepend'] as $file) {
+        $output .= $file->render();
+      }
+
+      $output .= $this->getTwig()->render($page->template->name . '.' . wire('config')->templateExtension, $twigVars);
+
+      foreach ($files['append'] as $file) {
+        $output .= $file->render();
+      }
+
+      return $output;
+    }
+
 }


### PR DESCRIPTION
I wanted to use

``` php
$config->prependTemplateFile = '_init.php';
$config->appendTemplateFile = '_done.php';
```

functionality but it does not work. This fix works for me but maybe there is a better way to solve it.

I added some code in **function renderPageWithTwig**

``` php
$defaultOptions = array(
+  'prependFile' => $page->template->noPrependTemplateFile ? null : $config->prependTemplateFile,
+  'prependFiles' => $page->template->prependFile ? array($page->template->prependFile) : array(),
+  'appendFile' => $page->template->noAppendTemplateFile ? null : $config->appendTemplateFile,
+  'appendFiles' => $page->template->appendFile ? array($page->template->appendFile) : array(),
    'forceBuildCache' => false,
);
```

``` php
+  $files = $this->getPrependAppendFiles($page, $options, $config);
+  $output = $this->combineOutput($files, $page);
```

Please have a look at **getPrependAppendFiles** and **combineOutput** at the end.
